### PR TITLE
Make the $contextly class a global so that we can hook into remove_action

### DIFF
--- a/contextly-linker.php
+++ b/contextly-linker.php
@@ -32,5 +32,6 @@ if ( is_admin() ) {
 }
 
 // Init Contextly
+global $contextly; 
 $contextly = new Contextly();
 $contextly->init();


### PR DESCRIPTION
Can't hook in and remove actions currently because we don't have access to your $contextly object. This should remedy that. 